### PR TITLE
Task Progress: Press `Enter` to reset the count

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -87,5 +87,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/task-progress/task-progress.component.ts
+++ b/src/app/task-progress/task-progress.component.ts
@@ -97,9 +97,16 @@ export class TaskProgressComponent {
 
   // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx //
 
-  public loadStats = this.currentLoadCount.pipe(
+  public reset$ = fromEvent(document, 'keypress').pipe(
+    map(value => 'reset'),
+  )
+
+  public loadStats = merge(this.currentLoadCount, this.reset$).pipe(
     scan(
-      (loadStats, loadingUpdate) => {
+      (loadStats: any, loadingUpdate: any) => {
+        if(loadingUpdate === 'reset'){
+          return  { total: 0, completed: 0, previousLoading: 0 }
+        }
         const loadsWentDown: boolean =
           loadingUpdate < loadStats.previousLoading;
         const currentCompleted: number = loadsWentDown


### PR DESCRIPTION
* **Commits** by **Caio Sampaio**

<hr>

## Notes

- Basically, an observable was added to emit when the `currentLoadCountObservable ` should reset its `scan` (The accumulated value on it). To do that, I merge these two observables, So the `scan` can get both values emitted. Of course, it is not the right solution is just a test to show the path. The idea is implement the condition you desire to active the new Observable